### PR TITLE
Comment warning

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,8 @@ export function validateSolidityTypeInstance(value: JSBI, solidityType: Solidity
 export function validateAndParseAddress(address: string): string {
   try {
     const checksummedAddress = getAddress(address)
-    warning(address === checksummedAddress, `${address} is not checksummed.`)
+    // this needs to be uncommented before prod MVP
+    // warning(address === checksummedAddress, `${address} is not checksummed.`)
     return checksummedAddress
   } catch (error) {
     invariant(false, `${address} is not a valid address.`)


### PR DESCRIPTION
The checksum warnings were causing the console to explode. This needs to be investigated before MVP. Uncommented so it doesn't slow down devs.